### PR TITLE
automate rampler lookup in racon_wrapper

### DIFF
--- a/scripts/racon_wrapper.py
+++ b/scripts/racon_wrapper.py
@@ -13,6 +13,9 @@ class RaconWrapper:
     __racon = '@racon_path@'
     __rampler = '@rampler_path@'
 
+    if(not os.path.exists(__rampler) and shutil.which("rampler")):
+        __rampler = shutil.which("rampler")
+
     def __init__(self, sequences, overlaps, target_sequences, split, subsample,
         include_unpolished, fragment_correction, window_length, quality_threshold,
         error_threshold, match, mismatch, gap, threads,


### PR DESCRIPTION
Honestly, its kind of an ugly hack because I'm trying to preserve current functionality where it makes sense but this should just work and should fix the issues with rampler when using the racon_wrapper when conda installing racon.